### PR TITLE
chore(deps): add Dependabot config targeting develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: develop
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` so Dependabot targets `develop` (matching Renovate's `baseBranches`)
- Covers `npm` and `github-actions` ecosystems on a weekly schedule

Motivation: PRs #125 and #126 landed on `main` because Dependabot defaults to the default branch when no config is present. This aligns both bots on `develop`.

## Test plan
- [ ] CI passes on this PR
- [ ] Next Dependabot PR opens against `develop`